### PR TITLE
Fix: displaying relation manager in infolist

### DIFF
--- a/resources/views/forms/relation-manager.blade.php
+++ b/resources/views/forms/relation-manager.blade.php
@@ -12,7 +12,7 @@
 
     $normalizedManagerClass = $normalizeRelationManagerClass($manager);
 
-    $managerLivewireProperties = ['lazy' => $isLazy, 'ownerRecord' => $this->getRecord(), 'pageClass' => $this::class];
+    $managerLivewireProperties = ['lazy' => $isLazy, 'ownerRecord' => $record(), 'pageClass' => $this::class];
 @endphp
 
 

--- a/resources/views/infolists/relation-manager.blade.php
+++ b/resources/views/infolists/relation-manager.blade.php
@@ -12,7 +12,7 @@
 
     $normalizedManagerClass = $normalizeRelationManagerClass($manager);
 
-    $managerLivewireProperties = ['lazy' => $isLazy, 'ownerRecord' => $this->getRecord(), 'pageClass' => $this::class];
+    $managerLivewireProperties = ['lazy' => $isLazy, 'ownerRecord' => $record(), 'pageClass' => $this::class];
 @endphp
 
 

--- a/src/Forms/RelationManager.php
+++ b/src/Forms/RelationManager.php
@@ -41,4 +41,9 @@ class RelationManager extends Component
     {
         return (bool) $this->evaluate($this->isLazy);
     }
+
+    public function record(): ?Model
+    {
+        return $this->getRecord();
+    }
 }

--- a/src/Infolists/RelationManager.php
+++ b/src/Infolists/RelationManager.php
@@ -41,4 +41,9 @@ class RelationManager extends Component
     {
         return (bool) $this->evaluate($this->isLazy);
     }
+
+    public function record(): ?Model
+    {
+        return $this->getRecord();
+    }
 }


### PR DESCRIPTION
This PR fixes the same thing as https://github.com/njxqlus/filament-relation-manager-component/pull/34 but for Filament v3.

I think you should not merge this to `main`,  instead of you should create branch `filament-v3` from 1.1.0 version, merge this PR to `filament-v3` and create release 1.1.1 from `filament-v3` branch.