### PR TITLE
Laravel 13.x Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^8.1",
         "filament/filament": "^3.0",
         "spatie/laravel-package-tools": "^1.15.0",
-        "illuminate/contracts": "^10.0|^11.0|^12.0"
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",


### PR DESCRIPTION
Adds Laravel 13 support to the `filament-v3` (Filament v3) line by widening the `illuminate/contracts` constraint.

## Summary
- `illuminate/contracts`: `^10.0|^11.0|^12.0` → `^10.0|^11.0|^12.0|^13.0`

No source changes are required — the package only uses `Illuminate\Database\Eloquent\Model` as a type hint plus Filament v3 APIs, none of which changed in Laravel 13.